### PR TITLE
Remove doc incompletion admonition

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,11 +20,7 @@ VB.NET.
 
 .. note::
 
-  EdgeDB version 2.0 and above are required to use EdgeDB.Net.
-
-.. note:: 
-
-  The documentation surrounding EdgeDB.Net has not yet been finalised.
+  EdgeDB version 2.0 and above is required to use EdgeDB.Net.
 
 .. _edgedb-dotnet-installing:
 


### PR DESCRIPTION
This resolves #15 by removing the aforementioned admonition. All current documentation should reflect v1.x of the driver and as such is no longer needed. Any additional changes or further releases should be treated as separate versions with their own respective admonitions stating so.