### PR TITLE
Change docs build trigger

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,9 +1,8 @@
 name: Docs Build
 
 on:
-  - push
-  - pull_request
-
+  release:
+    types: [released]
 env: 
   BuildNumber: "${{ github.run_number }}"
 


### PR DESCRIPTION
Discussed within Discord, here are my reasons for making this proposal:

- Documentation ideally doesn't require to be re-built from source unless a new version is being released. Testing documentation changes should be done locally through the contributor instead.
- Numerous commits being created within a short timespan could rapid-fire numerous GitHub worker runners, risking [potential rate limits](https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-rate-limits) and unfair usage of GitHub's Web API.

This change enforces the following:

- Documentation is only built when a tag is released and not set as a *pre-release,* e.g. an alphanumeric-based build or release candidate labeled as such in GitHub.
- Commits, Pull Requests and pushes (including rebases) are no longer the trigger basis. This means building documentation for testing purposes will need to be done locally (and ideally) pushed by the contributor beforehand.

Other reasons that may be more trivial:

- The EdgeDB.Net `DocGenerator` produces duplicates of existing callables for functions, methods and classes; and could theoretically happen more every time a commit is made surrounding changes to the driver's source documentation.
- Documentation is always rebuilt per commit regardless of which files are being changed, or whether the source documentation is changed or not. This may not be the best practice. 
  - Alternatively, having a `docs` branch and setting the build trigger to target that may also work.