### PR TITLE
Allow feature request Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,9 @@
+---
+name: Feature request
+about: Suggest a feature for EdgeDB.Net
+
+---
+
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+<!-- Describe the feature you'd like to see implemented in EdgeDB.Net. -->


### PR DESCRIPTION
Allows users to post feature request Issues while using the same template as found in [`edgedb/edgedb`](https://github.com/edgedb/edgedb).

GitHub allows users to create Issues if the thing they wanted was not found, but this proposal makes the Issue process more consistent