### PR TITLE
Fix lazy cache lookup reusing other codecs

### DIFF
--- a/src/EdgeDB.Net.Driver/Binary/Builders/CodecBuilder.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/CodecBuilder.cs
@@ -39,6 +39,8 @@ namespace EdgeDB.Binary
         /// </summary>
         public static readonly ConcurrentDictionary<Type, ICodec> CodecInstanceCache = new();
 
+        public static readonly ConcurrentDictionary<int, ICodec> CompiledCodecCache = new();
+
         public static readonly Guid NullCodec = Guid.Empty;
         public static readonly Guid InvalidCodec = Guid.Parse("ffffffffffffffffffffffffffffffff");
 

--- a/src/EdgeDB.Net.Driver/Binary/Codecs/Visitors/TypeVisitor.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Codecs/Visitors/TypeVisitor.cs
@@ -124,7 +124,7 @@ namespace EdgeDB.Binary.Codecs
                         {
                             VisitCodec(ref tmp);
 
-                            codec = compilable.Compile(tmp);
+                            codec = compilable.Compile(Context.Type, tmp);
 
                             _logger.CodecVisitorCompiledCodec(Depth, compilable, codec, Context.Type);
                         }


### PR DESCRIPTION
## Summary
When compiling a `CompilableCodec`, the compiled version was cached under the generic type of the codec, there was a issue when the compliable wrapped object codecs or codecs that are non-dependent on their generic definition to represent *what* they deserialize, causing user-defined types to be deserialized incorrectly.

This PR fixes that by caching the compiled codecs based off of both the user-specified type and the generic by using a combined hashcode.

Closes #37 