### PR TITLE
fix case when parameter status for concurrency isn't sent

### DIFF
--- a/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
@@ -79,7 +79,7 @@ namespace EdgeDB
             => _codecContext;
 
         internal byte[] ServerKey;
-        internal int SuggestedPoolConcurrency;
+        internal int? SuggestedPoolConcurrency;
         internal Dictionary<string, object?> RawServerConfig = new();
         
         internal readonly ILogger Logger;
@@ -711,10 +711,11 @@ namespace EdgeDB
                 {
                     case "suggested_pool_concurrency":
                         var str = Encoding.UTF8.GetString(status.ValueBuffer);
-                        if (!int.TryParse(str, out SuggestedPoolConcurrency))
+                        if (!int.TryParse(str, out var suggestedPoolConcurrency))
                         {
                             throw new FormatException("suggested_pool_concurrency type didn't match the expected type of int");
                         }
+                        SuggestedPoolConcurrency = suggestedPoolConcurrency;
                         break;
 
                     case "system_config":

--- a/src/EdgeDB.Net.Driver/EdgeDBClient.cs
+++ b/src/EdgeDB.Net.Driver/EdgeDBClient.cs
@@ -362,8 +362,10 @@ namespace EdgeDB
 
                         async ValueTask OnConnect(BaseEdgeDBClient _)
                         {
-                            _poolSize = client.SuggestedPoolConcurrency;
-                            await _poolHolder.ResizeAsync(_poolSize).ConfigureAwait(false);
+                            if(client.SuggestedPoolConcurrency.HasValue && !_poolConfig.HasCustomPoolSize)
+                            {
+                                await _poolHolder.ResizeAsync(_poolSize).ConfigureAwait(false);
+                            }
 
                             if (
                                 _edgedbConfig is null ||

--- a/src/EdgeDB.Net.Driver/EdgeDBConfig.cs
+++ b/src/EdgeDB.Net.Driver/EdgeDBConfig.cs
@@ -17,7 +17,7 @@ namespace EdgeDB
         /// </summary>
         public int DefaultPoolSize
         {
-            get => _poolSize;
+            get => _poolSize ?? 50;
             set
             {
                 if (value <= 0)
@@ -39,7 +39,10 @@ namespace EdgeDB
         /// </remarks>
         internal Func<ulong, EdgeDBConnection, EdgeDBConfig, ValueTask<BaseEdgeDBClient>>? ClientFactory { get; set; }
 
-        private int _poolSize = 50;
+        internal bool HasCustomPoolSize
+            => _poolSize.HasValue;
+
+        private int? _poolSize;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
The behavior for pool concurrency relies on the parameter status message containing the `suggested_pool_concurrency` value, if this message isn't sent, the client will attempt to rescale the pool to `0` which is invalid, throwing a `System.ArgumentOutOfRangeException`.

Closes #39