### PR TITLE
fix connection phase ignoring server errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     name: Run test suite
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Run test suite
 
     steps:

--- a/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
@@ -800,6 +800,9 @@ namespace EdgeDB
                     if (message is ReadyForCommand)
                         break;
 
+                    if(message is ErrorResponse err)
+                        throw new EdgeDBErrorException(err);
+
                     await HandlePacketAsync(message).ConfigureAwait(false);
                 }
 


### PR DESCRIPTION
## Summary
The binding doesn't propagate errors received from the server during the connection phase. If an error response is sent after a client handshake, the error is logged and the client continues to execute; disregarding the error.

Example flow:
```
13:19:08 - Debug: C->S: Client 1: ClientHandshake len: 50
13:19:08 - Debug: S->C: Client 1: ErrorResponse len: 348
13:19:08 - Error: Got error level: Error Message: ...
(client continues to perform execution)
13:19:08 - Debug: C->S: Client 1: Parse len: 120
...
```

This PR adds a check for an error in the connection phase, propagating it as an exception if one is received.