### PR TITLE
Fix reconnection deadlock on auth phase

### DIFF
--- a/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
@@ -789,7 +789,7 @@ namespace EdgeDB
                     {
                         await HandlePacketAsync(message).ConfigureAwait(false);
                     }
-                    catch(Exception x)
+                    catch(EdgeDBErrorException x) when (x.ShouldReconnect)
                     {
                         if (_config.RetryMode is ConnectionRetryMode.AlwaysRetry)
                         {

--- a/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
@@ -666,30 +666,6 @@ namespace EdgeDB
                     }
                 }
             }
-            catch(EdgeDBException x) when (x.ShouldReconnect)
-            {
-                await ReconnectAsync().ConfigureAwait(false);
-                throw;
-            }
-            catch (Exception x)
-            {
-                if (_config.RetryMode is ConnectionRetryMode.AlwaysRetry)
-                {
-                    if (_currentRetries < _config.MaxConnectionRetries)
-                    {
-                        _currentRetries++;
-                        Logger.AttemptToReconnect(_currentRetries, _config.MaxConnectionRetries);
-                        await ReconnectAsync();
-                    }
-                    else
-                        Logger.MaxConnectionRetries(_config.MaxConnectionRetries);
-                }
-                else
-                {
-                    Logger.AuthenticationFailed(x);
-                    throw;
-                }
-            }
             finally
             {
                 IsIdle = true;
@@ -781,6 +757,11 @@ namespace EdgeDB
         {
             await _connectSemaphone.WaitAsync(token).ConfigureAwait(false);
 
+            if (IsConnected)
+                return;
+
+            var released = false;
+
             try
             {
                 await ConnectInternalAsync(token: token);
@@ -798,9 +779,46 @@ namespace EdgeDB
                         throw new UnexpectedDisconnectException();
 
                     if (message is ReadyForCommand)
+                    {
+                        // reset connection attempts
+                        _currentRetries = 0;
                         break;
+                    }
 
-                    await HandlePacketAsync(message).ConfigureAwait(false);
+                    try
+                    {
+                        await HandlePacketAsync(message).ConfigureAwait(false);
+                    }
+                    catch(Exception x)
+                    {
+                        if (_config.RetryMode is ConnectionRetryMode.AlwaysRetry)
+                        {
+                            if (_currentRetries < _config.MaxConnectionRetries)
+                            {
+                                _currentRetries++;
+
+                                Logger.AttemptToReconnect(_currentRetries, _config.MaxConnectionRetries, x);
+
+                                // do not forward the linked token in this method to the new
+                                // reconnection, only supply the external token. We also don't
+                                // want to call 'ReconnectAsync' since we queue up a disconnect
+                                // and connect request, if this method was called externally
+                                // while we handle the error, it would be next in line to attempt
+                                // to connect, if that external call completes we would then disconnect
+                                // and connect after a successful connection attempt which wouldn't be ideal.
+                                await DisconnectAsync(token);
+
+                                _connectSemaphone.Release();
+
+                                await ConnectAsync(token);
+                                return;
+                            }
+                            else
+                                Logger.MaxConnectionRetries(_config.MaxConnectionRetries, x);
+                        }
+
+                        throw;
+                    }
                 }
 
                 _readySource.SetResult();
@@ -810,7 +828,8 @@ namespace EdgeDB
             }
             finally
             {
-                _connectSemaphone.Release();
+                if(!released)
+                    _connectSemaphone.Release();
             }
         }
 

--- a/src/EdgeDB.Net.Driver/Log.cs
+++ b/src/EdgeDB.Net.Driver/Log.cs
@@ -39,14 +39,14 @@ namespace EdgeDB
             LogLevel.Warning,
             "Attempting to reconnect {Current}/{Max}"
         )]
-        public static partial void AttemptToReconnect(this ILogger logger, uint current, uint max);
+        public static partial void AttemptToReconnect(this ILogger logger, uint current, uint max, Exception? exception = null);
 
         [LoggerMessage(
             6,
             LogLevel.Error,
             "Max number of connection retries reached ({Max})"
         )]
-        public static partial void MaxConnectionRetries(this ILogger logger, uint max);
+        public static partial void MaxConnectionRetries(this ILogger logger, uint max, Exception? exception = null);
 
         [LoggerMessage(
             7,


### PR DESCRIPTION
## Summary
When the binding receives an [`ErrorResponse`](https://www.edgedb.com/docs/reference/protocol/messages#ref-protocol-msg-error) from the server during the [authentication phase](https://www.edgedb.com/docs/reference/protocol/index#authentication), it will attempt to reconnect. The issue with this is that the `ConnectAsync` method is gated with a single permit semaphore which causes a deadlock in the following:
```
ConnectAsync
-> HandlePacketAsync
     -> (ErrorResponse) ReconnectAsync
          -> ConnectAsync
```

This PR fixes this by controlling the reconnect logic in the `ConnectAsync` method rather than its dependents.

Fixes #39 