### PR TITLE
Fix object codecs being reused based on shape

### DIFF
--- a/src/EdgeDB.Net.Driver/Binary/Builders/Info/EdgeDBTypeDeserializerInfo.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/Info/EdgeDBTypeDeserializerInfo.cs
@@ -49,8 +49,6 @@ namespace EdgeDB
 
             _factory = CreateDefaultFactory();
 
-            UpdateCodecsWithFactory(type, _factory);
-
             EdgeDBTypeName = _type.GetCustomAttribute<EdgeDBTypeAttribute>()?.Name ?? _type.Name;
 
             _typeActivator = CreateActivator();
@@ -72,7 +70,6 @@ namespace EdgeDB
 
             _typeActivator = CreateActivator();
             _factory = factory;
-            UpdateCodecsWithFactory(type, _factory);
         }
 
         private ObjectActivator? CreateActivator()
@@ -98,7 +95,6 @@ namespace EdgeDB
         public void UpdateFactory(TypeDeserializerFactory factory)
         {
             _factory = factory;
-            UpdateCodecsWithFactory(_type, _factory);
         }
 
         private TypeDeserializerFactory CreateDefaultFactory()
@@ -296,18 +292,6 @@ namespace EdgeDB
                 throw new InvalidOperationException($"No empty constructor found on type {_type}");
 
             return _typeActivator();
-        }
-
-        private static void UpdateCodecsWithFactory(Type type, TypeDeserializerFactory factory)
-        {
-            var codecs = CodecBuilder.CachedCodecs
-                .Where(x => x is Binary.Codecs.ObjectCodec obj && obj.TargetType == type)
-                .Cast<Binary.Codecs.ObjectCodec>();
-
-            foreach(var codec in codecs)
-            {
-                codec.UpdateFactory(factory);
-            }   
         }
 
         public object? Deserialize(ref ObjectEnumerator enumerator)

--- a/src/EdgeDB.Net.Driver/Binary/Builders/ObjectEnumerator.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/ObjectEnumerator.cs
@@ -20,7 +20,6 @@ namespace EdgeDB
         public int Length => _names.Length;
         internal PacketReader Reader;
         internal readonly ICodec[] Codecs;
-        private readonly EdgeDBTypeDeserializeInfo? _deserializerInfo;
         private readonly string[] _names;
         private readonly int _numElements;
         private readonly CodecContext _context;
@@ -31,14 +30,12 @@ namespace EdgeDB
             int position,
             string[] names,
             ICodec[] codecs,
-            EdgeDBTypeDeserializeInfo? deserializerInfo,
             CodecContext context)
         {
             Reader = new PacketReader(ref data, position);
             Codecs = codecs;
             _names = names;
             _pos = 0;
-            _deserializerInfo = deserializerInfo;
             _context = context;
 
             _numElements = Reader.ReadInt32();

--- a/src/EdgeDB.Net.Driver/Binary/Builders/TypeBuilder.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/TypeBuilder.cs
@@ -158,7 +158,8 @@ namespace EdgeDB
                 ScanAssemblyForTypes(type.Assembly);
             }
 
-            codec.Initialize(type);
+            if (codec is not TypeInitializedObjectCodec typeCodec)
+                codec = codec.GetOrCreateTypeCodec(type);
 
             var reader = new PacketReader(data.PayloadBuffer);
             return codec.Deserialize(ref reader, client.CodecContext);

--- a/tests/EdgeDB.Tests.Benchmarks/TypeBuilderBenchmarks.cs
+++ b/tests/EdgeDB.Tests.Benchmarks/TypeBuilderBenchmarks.cs
@@ -38,7 +38,7 @@ namespace EdgeDB.Tests.Benchmarks
                 "name",
                 "email"
             });
-            Codec.Initialize(typeof(Person));
+            Codec = Codec.GetOrCreateTypeCodec(typeof(Person));
         }
 
         [Benchmark]


### PR DESCRIPTION
## Summary
This PR fixes object codecs being reused when the shape matches, regardless of the user supplied type.

### Changes
Object codecs now strictly deserialize to `dynamic`, unless concrete type information is supplied. When type information is available, the object codec will create a child codec key'd by the type, inheriting the shape information.

Fixes #47 