### PR TITLE
Fix anonymous type deserialization

### DIFF
--- a/src/EdgeDB.Net.Driver/Binary/Builders/Info/EdgeDBTypeConstructorInfo.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/Info/EdgeDBTypeConstructorInfo.cs
@@ -47,11 +47,8 @@ namespace EdgeDB
                 if (!ctorParams.Any())
                     emptyCtor = ctor;
 
-                if (ctorParams.Length == 1)
+                if (ctorParams.Length == 1 && ctor.GetCustomAttribute<EdgeDBDeserializerAttribute>() is not null)
                 {
-                    if (ctor.GetCustomAttribute<EdgeDBDeserializerAttribute>() is null)
-                        continue;
-
                     var param = ctorParams[0];
 
                     UpgradeInfo(ref info, new EdgeDBTypeConstructorInfo

--- a/src/EdgeDB.Net.Driver/Binary/Builders/TypeBuilder.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/TypeBuilder.cs
@@ -197,6 +197,7 @@ namespace EdgeDB
                 type.IsAssignableTo(typeof(ITuple)) ||
                 type.IsAbstract ||
                 type.IsRecord() ||
+                type.IsAnonymousType() ||
                 (type.IsClass || type.IsValueType)
                 && EdgeDBTypeConstructorInfo.TryGetConstructorInfo(type, out _);
         }

--- a/src/EdgeDB.Net.Driver/Extensions/TypeExtensions.cs
+++ b/src/EdgeDB.Net.Driver/Extensions/TypeExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -8,6 +9,10 @@ namespace EdgeDB
 {
     internal static class TypeExtensions
     {
+        public static bool IsAnonymousType(this Type type)
+            => type.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Length > 0 &&
+               type.FullName!.Contains("AnonymousType");
+
         public static bool IsRecord(this Type type)
             => type.GetMethods().Any(m => m.Name == "<Clone>$");
 

--- a/src/EdgeDB.Net.Driver/Utils/TypeArgumentUtils.cs
+++ b/src/EdgeDB.Net.Driver/Utils/TypeArgumentUtils.cs
@@ -83,11 +83,7 @@ namespace EdgeDB
         private static readonly ConcurrentDictionary<Type, ITypeArgumentBuilder> _builders = new();
 
         public static bool IsValidArgumentType(Type type)
-            => _builders.ContainsKey(type) ||
-                (
-                    type.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Length > 0 &&
-                    type.FullName!.Contains("AnonymousType")
-                );
+            => _builders.ContainsKey(type) || type.IsAnonymousType();
 
         [return: NotNullIfNotNull(nameof(value))]
         public static IDictionary<string, object?>? CreateArguments(Type type, object? value)


### PR DESCRIPTION
## Summary
This PR fixes an issue where anonymous types would fail the `IsValidType` check for the deserialization pipeline, causing a `NoTypeConverterException` to be thrown.

The binding would attempt to search for a valid constructor for the anonymous type: if the type has only one property then it would assume a custom deserializer was being used, and would fail when it didn't find it.

