### PR TITLE
Fix F# option interop

### DIFF
--- a/src/EdgeDB.Net.Driver/Binary/Builders/Info/EdgeDBTypeConstructorInfo.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/Info/EdgeDBTypeConstructorInfo.cs
@@ -47,11 +47,8 @@ namespace EdgeDB
                 if (!ctorParams.Any())
                     emptyCtor = ctor;
 
-                if (ctorParams.Length == 1)
+                if (ctorParams.Length == 1 && ctor.GetCustomAttribute<EdgeDBDeserializerAttribute>() is not null)
                 {
-                    if (ctor.GetCustomAttribute<EdgeDBDeserializerAttribute>() is null)
-                        continue;
-
                     var param = ctorParams[0];
 
                     UpgradeInfo(ref info, new EdgeDBTypeConstructorInfo
@@ -72,9 +69,10 @@ namespace EdgeDB
                         Constructor = ctor
                     });
                 }
-                else if (ctorParams.Length == map.Properties.Length && ctorParams.Length != 0)
+
+                if (ctorParams.Length == map.Properties.Length && ctorParams.Length != 0)
                 {
-                    bool valid = true;
+                    var valid = true;
                     for (var i = 0; i != ctorParams.Length; i++)
                     {
                         var param = ctorParams[i];

--- a/src/EdgeDB.Net.Driver/Binary/Codecs/ObjectCodec.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Codecs/ObjectCodec.cs
@@ -1,4 +1,5 @@
 using EdgeDB.Binary;
+using EdgeDB.Utils.FSharp;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using System.Collections;
@@ -165,6 +166,17 @@ namespace EdgeDB.Binary.Codecs
 
                 // reserved
                 writer.Write(0);
+
+                if (FSharpOptionInterop.TryGet(element, out var option))
+                {
+                    if(!option.HasValue)
+                    {
+                        writer.Write(-1);
+                        continue;
+                    }
+
+                    element = option.Value;
+                }
 
                 // encode
                 if (element is null)

--- a/src/EdgeDB.Net.Driver/Extensions/TypeExtensions.cs
+++ b/src/EdgeDB.Net.Driver/Extensions/TypeExtensions.cs
@@ -32,7 +32,13 @@ namespace EdgeDB
 
             if (type.IsGenericType)
             {
+                if (type.IsFSharpOption() || type.IsFSharpValueOption())
+                {
+                    return type.GenericTypeArguments[0];
+                }
+
                 var genDef = type.GetGenericTypeDefinition();
+
                 if (genDef == typeof(DataTypes.Range<>))
                 {
                     return type.GenericTypeArguments[0];

--- a/src/EdgeDB.Net.Driver/Utils/FSharp/FSharpOptionInterop.cs
+++ b/src/EdgeDB.Net.Driver/Utils/FSharp/FSharpOptionInterop.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Utils.FSharp
+{
+    internal readonly ref struct FSharpOptionInterop
+    {
+        private static PropertyInfo? _isSomeProperty;
+        private static PropertyInfo? _getValueProperty;
+
+        public object? Value
+            => _value;
+
+        public bool HasValue
+            => _hasValue;
+
+        private readonly object? _value;
+        private readonly bool _hasValue;
+        private readonly Type _type;
+
+        private FSharpOptionInterop(object? obj)
+        {
+            _type = obj?.GetType() ?? typeof(object);
+
+            if (obj is null)
+                return;
+
+            if (!(_type.IsFSharpOption() || _type.IsFSharpValueOption()))
+                throw new InvalidOperationException($"The provided type {_type} is not an F# option");
+
+            _hasValue = (bool)GetIsSomeProperty(_type).GetValue(obj)!;
+
+            _value = HasValue
+                ? GetValueProperty(_type).GetValue(obj)
+                : null;
+        }
+
+        public static bool TryGet(object? value, out FSharpOptionInterop option)
+        {
+            if (value is null)
+            {
+                option = default;
+                return false;
+            }
+
+            var type = value.GetType();
+
+            if (type.IsFSharpOption() || type.IsFSharpValueOption())
+            {
+                option = new(value);
+                return true;
+            }
+
+            option = default;
+            return false;
+        }
+
+        private static PropertyInfo GetIsSomeProperty(Type type)
+            => _isSomeProperty ??= type.GetProperty("IsSome") ?? throw new MissingMethodException($"Can't find 'IsSome' property on {type}");
+
+        private static PropertyInfo GetValueProperty(Type type)
+            => _getValueProperty ??= type.GetProperty("Value") ?? throw new MissingMethodException($"Can't find 'GetValue' property on {type}");
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes both #55 and #54 by:
- Extracting the wrapping type of option when visiting codecs
- Extracting the value from options when serializing arguments
- Fixing anonymous types with option types (closely related to #56)

cc @Darkle