### PR TITLE
Add support for wrapping types in deserialization

### DIFF
--- a/src/EdgeDB.Net.Driver/Binary/Builders/TypeBuilder.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/TypeBuilder.cs
@@ -11,6 +11,7 @@ using EdgeDB.DataTypes;
 using System;
 using EdgeDB.Binary;
 using System.Diagnostics;
+using EdgeDB.Binary.Builders.Wrappers;
 
 namespace EdgeDB
 {
@@ -183,6 +184,10 @@ namespace EdgeDB
             // if its a scalar, defently don't try to use it.
             if (CodecBuilder.ContainsScalarCodec(type))
                 return false;
+
+            // if its a wrapping type we support, validate the inner type
+            if (IWrapper.TryGetWrapper(type, out var wrapper))
+                return IsValidObjectType(wrapper.GetInnerType(type));
 
             if (
                 type.IsAssignableTo(typeof(IEnumerable)) &&

--- a/src/EdgeDB.Net.Driver/Binary/Builders/Wrappers/FSharpOptionWrapper.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/Wrappers/FSharpOptionWrapper.cs
@@ -1,0 +1,54 @@
+using EdgeDB.Utils.FSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Binary.Builders.Wrappers
+{
+    internal sealed class FSharpOptionWrapper : IWrapper
+    {
+        private static ConstructorInfo? _valueOptionConstructor;
+        private static ConstructorInfo? _referenceOptionConstructor;
+
+        public Type GetInnerType(Type wrapperType)
+            => wrapperType.GenericTypeArguments[0];
+
+        public bool IsWrapping(Type t)
+            => t.IsFSharpOption() || t.IsFSharpValueOption();
+
+        public object? Wrap(Type target, object? value)
+        {
+            if (target.IsFSharpValueOption())
+                return WrapValueOption(target, value);
+            else if (target.IsFSharpOption())
+                return WrapReferenceOption(target, value);
+            else
+                throw new NotSupportedException($"Unsupported wrapping type: {target}");
+        }
+
+        private static object? WrapReferenceOption(Type target, object? value)
+        {
+            if (value is null)
+                return null;
+
+            return (
+                _referenceOptionConstructor ??= target.GetConstructor(new Type[] { value.GetType() })
+                    ?? throw new EdgeDBException($"Failed to find constructor for {target}")
+            ).Invoke(new object?[] { value });
+        }
+
+        private static object? WrapValueOption(Type target, object? value)
+        {
+            if (value is null)
+                return ReflectionUtils.GetDefault(target);
+
+            return (
+                _valueOptionConstructor ??= target.GetConstructor(new Type[] { value.GetType() })
+                    ?? throw new EdgeDBException($"Failed to find constructor for {target}")
+            ).Invoke(new object?[] { value });
+        }
+    }
+}

--- a/src/EdgeDB.Net.Driver/Binary/Builders/Wrappers/IWrapper.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/Wrappers/IWrapper.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Binary.Builders.Wrappers
+{
+    internal interface IWrapper
+    {
+        static readonly ConcurrentBag<IWrapper> _wrappers = new()
+        {
+            new FSharpOptionWrapper(),
+            new NullableWrapper()
+        };
+
+        static bool TryGetWrapper(Type t, [NotNullWhen(true)] out IWrapper? wrapper)
+            => (wrapper = _wrappers.FirstOrDefault(x => x.IsWrapping(t))) is not null;
+
+        /// <summary>
+        ///     Returns the inner (real) type that the wrapper wraps. For example:
+        ///     <see cref="Nullable"/>&lt;<see cref="int"/>&gt; would return <see cref="int"/>;
+        /// </summary>
+        /// <param name="wrapperType">The wrapper type to extract the inner type from.</param>
+        /// <returns>The inner type.</returns>
+        Type GetInnerType(Type wrapperType);
+
+        /// <summary>
+        ///     Determines whether or not this wrapper can work with the provided
+        ///     wrapping type.
+        /// </summary>
+        /// <param name="t">
+        ///     The type that is checked for a wrapper that this instance can work with.
+        /// </param>
+        /// <returns>
+        ///     <see langword="true"/> if the provided type matches the type this wrapper
+        ///     can work with; otherwise <see langword="false"/>.
+        /// </returns>
+        bool IsWrapping(Type t);
+
+        /// <summary>
+        ///     Wraps a given value into the target type.
+        /// </summary>
+        /// <param name="target">The target type of the wrap.</param>
+        /// <param name="value">The value to wrap.</param>
+        /// <returns>The wrapped value.</returns>
+        object? Wrap(Type target, object? value);
+    }
+}

--- a/src/EdgeDB.Net.Driver/Binary/Builders/Wrappers/NullableWrapper.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/Wrappers/NullableWrapper.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EdgeDB.Binary.Builders.Wrappers
+{
+    internal sealed class NullableWrapper : IWrapper
+    {
+        private ConstructorInfo? _constructor;
+
+        public Type GetInnerType(Type wrapperType)
+            => wrapperType.GenericTypeArguments[0];
+
+        public bool IsWrapping(Type t)
+            => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>);
+
+        public object? Wrap(Type target, object? value)
+        {
+            if (value is null)
+                return ReflectionUtils.GetDefault(target);
+
+            return (
+                _constructor ??= target.GetConstructor(new Type[] { value.GetType() })
+                    ?? throw new EdgeDBException($"Failed to find constructor for {target}")
+            ).Invoke(new object?[] { value });
+        }
+    }
+}

--- a/tests/EdgeDB.Tests.Integration/ClientTests.cs
+++ b/tests/EdgeDB.Tests.Integration/ClientTests.cs
@@ -23,6 +23,19 @@ namespace EdgeDB.Tests.Integration
         }
 
         [TestMethod]
+        public async Task TestNullableReturns()
+        {
+            var result = await EdgeDB.QuerySingleAsync<long?>("select <optional int64>$arg", new { arg = 1L });
+
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual(1L, result.Value);
+
+            result = await EdgeDB.QuerySingleAsync<long?>("select <optional int64>$arg", new { arg = (long?)null });
+
+            Assert.IsFalse(result.HasValue);
+        }
+
+        [TestMethod]
         public async Task TestCommandLocks()
         {
             await using var client = await EdgeDB.GetOrCreateClientAsync<EdgeDBBinaryClient>(token: _getToken());


### PR DESCRIPTION
## Summary
This PR adds another step in the deserialization pipeline which support wrapping types, ex: `Nullable<T>`, `Option<T>`, etc. It also fixes a bug with value type deserialization due to expression initialization by adding an explicit box operation.