### PR TITLE
Fix FSharp arguments being cached incorrectly

### DIFF
--- a/src/EdgeDB.Net.Driver/Utils/FSharp/FSharpOptionInterop.cs
+++ b/src/EdgeDB.Net.Driver/Utils/FSharp/FSharpOptionInterop.cs
@@ -9,9 +9,6 @@ namespace EdgeDB.Utils.FSharp
 {
     internal readonly ref struct FSharpOptionInterop
     {
-        private static PropertyInfo? _isSomeProperty;
-        private static PropertyInfo? _getValueProperty;
-
         public object? Value
             => _value;
 
@@ -32,15 +29,19 @@ namespace EdgeDB.Utils.FSharp
             if (!(_type.IsFSharpOption() || _type.IsFSharpValueOption()))
                 throw new InvalidOperationException($"The provided type {_type} is not an F# option");
 
-            _hasValue = (bool)GetIsSomeProperty(_type).GetValue(obj,
-                _isSomeProperty!.GetIndexParameters().Length > 0
+            var isSomeProperty = GetIsSomeProperty(_type);
+
+            _hasValue = (bool)isSomeProperty.GetValue(obj,
+                isSomeProperty!.GetIndexParameters().Length > 0
                     ? new object?[] { obj }
                     : null
             )!;
 
+            var getValueProperty = GetValueProperty(_type);
+
             _value = HasValue
-                ? GetValueProperty(_type).GetValue(obj,
-                    _getValueProperty!.GetIndexParameters().Length > 0
+                ? getValueProperty.GetValue(obj,
+                    getValueProperty!.GetIndexParameters().Length > 0
                         ? new object?[] { obj }
                         : null
                     )
@@ -68,9 +69,9 @@ namespace EdgeDB.Utils.FSharp
         }
 
         private static PropertyInfo GetIsSomeProperty(Type type)
-            => _isSomeProperty ??= type.GetProperty("IsSome") ?? throw new MissingMethodException($"Can't find 'IsSome' property on {type}");
+            => type.GetProperty("IsSome") ?? throw new MissingMethodException($"Can't find 'IsSome' property on {type}");
 
         private static PropertyInfo GetValueProperty(Type type)
-            => _getValueProperty ??= type.GetProperty("Value") ?? throw new MissingMethodException($"Can't find 'GetValue' property on {type}");
+            => type.GetProperty("Value") ?? throw new MissingMethodException($"Can't find 'GetValue' property on {type}");
     }
 }


### PR DESCRIPTION
## Summary
The binding would attempt to *globally* cache the `IsSome` and `GetValue` method on `FSharpOption<>`, the issue is that this type is *generic specific*, meaning if you had different option types like `option<int32>` and `option<bool>` it would throw an argument exception because of the type mismatch.

This PR fixes that by removing this behavior completely, the `IsSome` and `GetValue` methods are retrieved every time per type.

Fixes #65 