### PR TITLE
Optimize codec initialization

### DIFF
--- a/src/EdgeDB.Net.Driver/Binary/Builders/TypeBuilder.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/TypeBuilder.cs
@@ -27,11 +27,11 @@ namespace EdgeDB
         ///     using this naming strategy, the naming convention of the dotnet type will be preserved.
         /// </remarks>
         /// <remarks>
-        ///     If the naming strategy doesn't find a match, the 
+        ///     If the naming strategy doesn't find a match, the
         ///     <see cref="AttributeNamingStrategy"/> will be used.
         /// </remarks>
         public static INamingStrategy SchemaNamingStrategy { get; set; }
-        
+
         internal readonly static ConcurrentDictionary<Type, EdgeDBTypeDeserializeInfo> TypeInfo = new();
         internal readonly static ConcurrentDictionary<Type, IEdgeDBTypeConverter> TypeConverters = new();
         internal static readonly INamingStrategy AttributeNamingStrategy;
@@ -56,7 +56,7 @@ namespace EdgeDB
             if(!EdgeDBTypeConstructorInfo.TryGetConstructorInfo(typeof(TType), out var ctorInfo) || ctorInfo.EmptyConstructor is null)
                 throw new TargetInvocationException($"Cannot create an instance of {typeof(TType).Name}: no empty constructor found", null);
 
-            object Factory(ref ObjectEnumerator enumerator)
+            object? Factory(ref ObjectEnumerator enumerator)
             {
                 var instance = (TType)ctorInfo.EmptyConstructor.Invoke(Array.Empty<object>());
 
@@ -127,7 +127,7 @@ namespace EdgeDB
         internal static bool TryGetTypeDeserializerInfo(Type type, [MaybeNullWhen(false)] out EdgeDBTypeDeserializeInfo info)
         {
             info = null;
-            
+
             if (!IsValidObjectType(type))
                 return false;
 
@@ -138,15 +138,15 @@ namespace EdgeDB
             }
             else
                 info = typeInfo;
-            
+
             return info is not null;
         }
-        
+
         internal static object? BuildObject(EdgeDBBinaryClient client, Type type, Binary.Codecs.ObjectCodec codec, in ReadOnlyMemory<byte> data)
         {
             if (!IsValidObjectType(type))
                 throw new InvalidOperationException($"Cannot deserialize data to {type.Name}");
-            
+
             if (!TypeInfo.TryGetValue(type, out EdgeDBTypeDeserializeInfo? info))
             {
                 info = TypeInfo.AddOrUpdate(type, new EdgeDBTypeDeserializeInfo(type), (_, v) => v);
@@ -197,7 +197,7 @@ namespace EdgeDB
             }
 
             return
-                type == typeof(object) || 
+                type == typeof(object) ||
                 type.IsAssignableTo(typeof(ITuple)) ||
                 type.IsAbstract ||
                 type.IsRecord() ||
@@ -226,7 +226,7 @@ namespace EdgeDB
 
             return inst;
         }
-        
+
         internal static bool TryGetCustomBuilder(this Type objectType, out MethodInfo? info)
         {
             info = null;

--- a/src/EdgeDB.Net.Driver/EdgeDB.Net.Driver.csproj
+++ b/src/EdgeDB.Net.Driver/EdgeDB.Net.Driver.csproj
@@ -22,9 +22,15 @@
   <ItemGroup>
     <None Remove="ContractResolvers\" />
     <None Remove="Binary\Codecs\Visitors\" />
+    <None Remove="Binary\Packets\**" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Binary\Packets\" />
     <Folder Include="ContractResolvers\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Binary\Packets\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Remove="Binary\Packets\**" />
   </ItemGroup>
 </Project>

--- a/tests/EdgeDB.Tests.Benchmarks/EdgeDB.Tests.Benchmarks.csproj
+++ b/tests/EdgeDB.Tests.Benchmarks/EdgeDB.Tests.Benchmarks.csproj
@@ -10,7 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.13.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/EdgeDB.Tests.Benchmarks/FullExecuteBenchmark.cs
+++ b/tests/EdgeDB.Tests.Benchmarks/FullExecuteBenchmark.cs
@@ -1,13 +1,10 @@
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnostics.dotTrace;
 using EdgeDB.Tests.Benchmarks.Utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace EdgeDB.Tests.Benchmarks
 {
+    [DotTraceDiagnoser]
     public class FullExecuteBenchmark
     {
         public EdgeDBClient? Client;

--- a/tests/EdgeDB.Tests.Benchmarks/Program.cs
+++ b/tests/EdgeDB.Tests.Benchmarks/Program.cs
@@ -2,6 +2,6 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using EdgeDB.Tests.Benchmarks;
 
-BenchmarkRunner.Run<TypeBuilderBenchmarks>();
+BenchmarkRunner.Run<FullExecuteBenchmark>();
 
 await Task.Delay(-1);


### PR DESCRIPTION
## Summary
This PR adds a simple optimization by parallelizing the Execute <=> Initialize phase by "preheating" the codecs to their final form. The more complex (the number of different types and descriptors) a query is(has), the better the performance gain. This also gets gains from long-running queries, as while the binding waits for EdgeDB to return the data, it can preheat codecs.

### Small query benchmarks
```cs
await client.QueryAsync<string>("select \"Hello, World!\"");
```
<details>
<summary>
Click to show benchmark results
</summary>

**Before Optimization**
```
|           Method |     Mean |   Error |  StdDev |
|----------------- |---------:|--------:|--------:|
| FullExecuteAsync | 362.6 us | 7.09 us | 5.92 us |
```

**After Optimization**
```
| Method           | Mean     | Error   | StdDev  |
|----------------- |---------:|--------:|--------:|
| FullExecuteAsync | 355.1 us | 6.21 us | 5.51 us |

```

</details>

### Larger query benchmarks
```cs
public class Person
{
    [EdgeDBProperty("name")]
    public string? Name { get; set; }
    [EdgeDBProperty("email")]
    public string? Email { get; set; }
}
public class Movie
{
    [EdgeDBProperty("title")]
    public string? Title { get; set; }
    [EdgeDBProperty("year")]
    public int Year { get; set; }
    [EdgeDBProperty("director")]
    public Person? Director { get; set; }
    [EdgeDBProperty("actors")]
    public Person[]? Actors { get; set; }
}

await client.QueryAsync<Movie>("select Movie { actors: { email, name }, director: { email, name }, title, year }");
```
<details>
<summary>
Click to show benchmark results
</summary>

**Before Optimization**
```
|           Method |     Mean |   Error |  StdDev |
|----------------- |---------:|--------:|--------:|
| FullExecuteAsync | 442.3 us | 8.12 us | 7.98 us |
```

**After Optimization**
```
| Method           | Mean     | Error   | StdDev  |
|----------------- |---------:|--------:|--------:|
| FullExecuteAsync | 419.6 us | 8.37 us | 8.96 us |
```
