### PR TITLE
Don't parse if no args and result

### DIFF
--- a/src/EdgeDB.Net.Driver/Binary/Builders/CodecBuilder.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/CodecBuilder.cs
@@ -36,8 +36,12 @@ internal sealed class CodecBuilder
 {
     public static readonly ConcurrentDictionary<IProtocolProvider, CodecCache> CodecCaches = new();
 
-    public static readonly Guid NullCodec = Guid.Empty;
+    public static readonly Guid NullCodecId = Guid.Empty;
     public static readonly Guid InvalidCodec = Guid.Parse("ffffffffffffffffffffffffffffffff");
+
+    public static readonly NullCodec NullCodec = new NullCodec();
+
+    public static readonly CodecInfo NullCodecInfo = new(NullCodecId, NullCodec);
 
     private static readonly ConcurrentDictionary<ulong, (Guid InCodec, Guid OutCodec)> _codecKeyMap = new();
 
@@ -46,7 +50,7 @@ internal sealed class CodecBuilder
 
     private static readonly Dictionary<Guid, Type> _scalarCodecTypeMap = new()
     {
-        {NullCodec, typeof(NullCodec)},
+        {NullCodecId, typeof(NullCodec)},
         {new Guid("00000000-0000-0000-0000-000000000100"), typeof(UUIDCodec)},
         {new Guid("00000000-0000-0000-0000-000000000101"), typeof(TextCodec)},
         {new Guid("00000000-0000-0000-0000-000000000102"), typeof(BytesCodec)},
@@ -141,7 +145,7 @@ internal sealed class CodecBuilder
 
     public static ICodec BuildCodec(EdgeDBBinaryClient client, in Guid id, ref PacketReader reader)
     {
-        if (id == NullCodec)
+        if (id == NullCodecId)
             return GetOrCreateCodec<NullCodec>(client.ProtocolProvider);
 
         var providerCache = GetProviderCache(client.ProtocolProvider);

--- a/src/EdgeDB.Net.Driver/Binary/Protocol/IProtocolProvider.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Protocol/IProtocolProvider.cs
@@ -45,7 +45,7 @@ internal interface IProtocolProvider
 
     PacketReadFactory? GetPacketFactory(ServerMessageType type);
 
-    Task<ParseResult> ParseQueryAsync(QueryParameters query, CancellationToken token);
+    ValueTask<ParseResult> ParseQueryAsync(QueryParameters query, CancellationToken token);
 
     Task<ExecuteResult> ExecuteQueryAsync(QueryParameters query, ParseResult result, CancellationToken token);
 

--- a/src/EdgeDB.Net.Driver/Clients/EdgeDBTcpClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/EdgeDBTcpClient.cs
@@ -147,18 +147,22 @@ internal sealed class EdgeDBTcpClient : EdgeDBBinaryClient, ITransactibleClient
 
         var deferMode = $"{(!deferrable ? "not " : "")}deferrable";
 
-        await ExecuteInternalAsync($"start transaction isolation {isolationMode}, {readMode}, {deferMode}",
-            capabilities: Capabilities.Transaction, token: token).ConfigureAwait(false);
+        await ExecuteInternalAsync(
+            $"start transaction isolation {isolationMode}, {readMode}, {deferMode}",
+            capabilities: Capabilities.Transaction,
+            format: IOFormat.None,
+            token: token
+        ).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     async Task ITransactibleClient.CommitAsync(CancellationToken token)
-        => await ExecuteInternalAsync("commit", capabilities: Capabilities.Transaction, token: token)
+        => await ExecuteInternalAsync("commit", capabilities: Capabilities.Transaction, token: token, format: IOFormat.None)
             .ConfigureAwait(false);
 
     /// <inheritdoc />
     async Task ITransactibleClient.RollbackAsync(CancellationToken token)
-        => await ExecuteInternalAsync("rollback", capabilities: Capabilities.Transaction, token: token)
+        => await ExecuteInternalAsync("rollback", capabilities: Capabilities.Transaction, token: token, format: IOFormat.None)
             .ConfigureAwait(false);
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
This PR removes a round trip parse call in the case that there is no query arguments and output

Complies with https://github.com/edgedb/edgedb/pull/6576