### PR TITLE
Rename __tname__ to __tname

### DIFF
--- a/src/EdgeDB.Net.Driver/Binary/Builders/Info/EdgeDBTypeDeserializerInfo.cs
+++ b/src/EdgeDB.Net.Driver/Binary/Builders/Info/EdgeDBTypeDeserializerInfo.cs
@@ -274,7 +274,7 @@ internal sealed class EdgeDBTypeDeserializeInfo
             return (ref ObjectEnumerator enumerator) =>
             {
                 // introspect the type name
-                if (!enumerator.Next(out var name, out var value) || name != "__tname__")
+                if (!enumerator.Next(out var name, out var value) || name != "__tname")
                     throw new ConfigurationException(
                         "Type introspection is required for abstract types, this is a bug.");
 

--- a/tests/EdgeDB.Tests.Benchmarks/TypeBuilderBenchmarks.cs
+++ b/tests/EdgeDB.Tests.Benchmarks/TypeBuilderBenchmarks.cs
@@ -28,7 +28,7 @@ public class TypeBuilderBenchmarks
 
         Codec = new ObjectCodec(in Guid.Empty,
             new ICodec[] {new TextCodec(), new UUIDCodec(), new UUIDCodec(), new TextCodec(), new TextCodec()},
-            new[] {"__tname__", "__tid__", "id", "name", "email"});
+            new[] {"__tname", "__tid__", "id", "name", "email"});
         Codec = Codec.GetOrCreateTypeCodec(typeof(Person));
     }
 


### PR DESCRIPTION
HI! I use abstract types in EdgeDB and I cannot deserialize them with the .NET library.

I get an error when I try to query with a `__tname__` the following way:

```
__tname__ := .__type__.name
```

The exception coming from the database UI itself:

> EdgeQLSyntaxError: identifiers surrounded by double underscores are forbidden

<img width="1166" alt="image" src="https://github.com/user-attachments/assets/283077b0-1fc4-4ff4-8672-ab70e95937c1">


Thus, I propose a simple rename that works:
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/b02e2e88-6e67-40d5-bf8c-37b0b7e63d88">

Without it, deserialization fails with an exception:
`ConfigurationException("Type introspection is required for abstract types, this is a bug.");`, defined in the `/src/EdgeDB.Net.Driver/Binary/Builders/Info/EdgeDBTypeDeserializerInfo.cs`

Lastly, thank you for the great work!
