### PR TITLE
Expand functionality of ISystemProvider

### DIFF
--- a/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
+++ b/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
@@ -590,7 +590,7 @@ public sealed class EdgeDBConnection
     {
         platform ??= ConfigUtils.DefaultPlatformProvider;
 
-        var dir = Environment.CurrentDirectory;
+        var dir = platform.GetCurrentDirectory();
 
         while (true)
         {

--- a/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
+++ b/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
@@ -278,6 +278,13 @@ public sealed class EdgeDBConnection
     /// <exception cref="KeyNotFoundException">An environment variable couldn't be found.</exception>
     public static EdgeDBConnection FromDSN(string dsn)
     {
+        return _FromDSN(dsn, null);
+    }
+
+    internal static EdgeDBConnection _FromDSN(string dsn, ISystemProvider? platform)
+    {
+        platform ??= ConfigUtils.DefaultPlatformProvider;
+
         if (!dsn.StartsWith("edgedb://") && !dsn.StartsWith("gel://"))
             throw new ConfigurationException("DSN schema 'gel' expected but got 'pq'");
 
@@ -430,10 +437,10 @@ public sealed class EdgeDBConnection
                     break;
                 case "tls_cert_file":
                 {
-                    if (!File.Exists(value))
+                    if (!platform.FileExists(value))
                         throw new FileNotFoundException("The specified tls_cert_file file was not found");
 
-                    conn.TLSCertificateAuthority = File.ReadAllText(value);
+                    conn.TLSCertificateAuthority = platform.FileReadAllText(value);
                 }
                     break;
                 case "tls_security":
@@ -466,7 +473,7 @@ public sealed class EdgeDBConnection
 
             if (fileMatch.Success)
             {
-                var val = File.ReadAllText(arg.Value);
+                var val = platform.FileReadAllText(arg.Value);
 
                 SetArgument(fileMatch.Groups[1].Value, val, conn);
             }
@@ -500,7 +507,9 @@ public sealed class EdgeDBConnection
 
     internal static EdgeDBConnection _FromProjectFile(string path, ISystemProvider? platform)
     {
-        if (!File.Exists(path))
+        platform ??= ConfigUtils.DefaultPlatformProvider;
+
+        if (!platform.FileExists(path))
             throw new FileNotFoundException("Couldn't find the specified project file", path);
 
         path = Path.GetFullPath(path);
@@ -513,12 +522,12 @@ public sealed class EdgeDBConnection
         if (!Directory.Exists(projectDir))
             throw new DirectoryNotFoundException($"Couldn't find project directory for {path}: {projectDir}");
 
-        if (!ConfigUtils.TryResolveInstanceCloudProfile(projectDir, out var profile, out var inst) || inst is null)
+        if (!ConfigUtils.TryResolveInstanceCloudProfile(projectDir, out var profile, out var inst, platform) || inst is null)
             throw new FileNotFoundException($"Could not find instance name under project directory {projectDir}");
 
-        var connection = FromInstanceName(inst, profile);
+        var connection = _FromInstanceName(inst, profile, platform);
 
-        if (ConfigUtils.TryResolveProjectDatabase(projectDir, out var database))
+        if (ConfigUtils.TryResolveProjectDatabase(projectDir, out var database, platform))
             connection.Database = database;
 
         return connection;
@@ -545,13 +554,15 @@ public sealed class EdgeDBConnection
 
     internal static EdgeDBConnection _FromInstanceName(string name, string? cloudProfile, ISystemProvider? platform)
     {
+        platform ??= ConfigUtils.DefaultPlatformProvider;
+
         if (Regex.IsMatch(name, @"^\w(-?\w)*$"))
         {
             var configPath = Path.Combine(ConfigUtils.GetCredentialsDir(platform), $"{name}.json");
 
-            return !File.Exists(configPath)
+            return !platform.FileExists(configPath)
                 ? throw new FileNotFoundException($"Config file couldn't be found at {configPath}")
-                : JsonConvert.DeserializeObject<EdgeDBConnection>(File.ReadAllText(configPath))!;
+                : JsonConvert.DeserializeObject<EdgeDBConnection>(platform.FileReadAllText(configPath))!;
         }
 
         if (Regex.IsMatch(name, @"^([A-Za-z0-9](-?[A-Za-z0-9])*)\/([A-Za-z0-9](-?[A-Za-z0-9])*)$"))
@@ -572,12 +583,19 @@ public sealed class EdgeDBConnection
     /// <exception cref="FileNotFoundException">No 'edgedb.toml' file could be found.</exception>
     public static EdgeDBConnection ResolveEdgeDBTOML()
     {
+        return _ResolveEdgeDBTOML(null);
+    }
+
+    internal static EdgeDBConnection _ResolveEdgeDBTOML(ISystemProvider? platform)
+    {
+        platform ??= ConfigUtils.DefaultPlatformProvider;
+
         var dir = Environment.CurrentDirectory;
 
         while (true)
         {
-            if (File.Exists(Path.Combine(dir!, "edgedb.toml")))
-                return FromProjectFile(Path.Combine(dir!, "edgedb.toml"));
+            if (platform.FileExists(Path.Combine(dir!, "edgedb.toml")))
+                return _FromProjectFile(Path.Combine(dir!, "edgedb.toml"), platform);
 
             var parent = Directory.GetParent(dir!);
 
@@ -770,6 +788,8 @@ public sealed class EdgeDBConnection
     internal static EdgeDBConnection _Parse(string? instance, string? dsn,
         Action<EdgeDBConnection>? configure, bool autoResolve, ISystemProvider? platform)
     {
+        platform ??= ConfigUtils.DefaultPlatformProvider;
+
         EdgeDBConnection? connection = null;
 
         // try to resolve the toml, don't do this for cloud-like conn params.
@@ -778,7 +798,7 @@ public sealed class EdgeDBConnection
         {
             try
             {
-                connection = ResolveEdgeDBTOML();
+                connection = _ResolveEdgeDBTOML(platform);
             }
             catch (FileNotFoundException)
             {
@@ -816,13 +836,13 @@ public sealed class EdgeDBConnection
 
         if (GetEnvVariable(env, INSTANCE_ENV_NAME, out envName, out envVar))
         {
-            var fromInst = FromInstanceName(envVar);
+            var fromInst = _FromInstanceName(envVar, null, platform);
             connection = connection?.MergeInto(fromInst) ?? fromInst;
         }
 
         if (GetEnvVariable(env, DSN_ENV_NAME, out envName, out envVar))
         {
-            var fromDSN = FromDSN(envVar);
+            var fromDSN = _FromDSN(envVar, platform);
             connection = connection?.MergeInto(fromDSN) ?? fromDSN;
         }
 
@@ -861,11 +881,11 @@ public sealed class EdgeDBConnection
         {
             // check if file exists
             var path = envVar;
-            if (!File.Exists(path))
+            if (!platform.FileExists(path))
                 throw new FileNotFoundException(
                     $"Could not find the file specified in '{envName}'");
 
-            var credentials = JsonConvert.DeserializeObject<EdgeDBConnection>(File.ReadAllText(path))!;
+            var credentials = JsonConvert.DeserializeObject<EdgeDBConnection>(platform.FileReadAllText(path))!;
             connection = connection?.MergeInto(credentials) ?? credentials;
         }
 
@@ -902,7 +922,7 @@ public sealed class EdgeDBConnection
 
         if (instance is not null)
         {
-            var fromInst = FromInstanceName(instance);
+            var fromInst = _FromInstanceName(instance, null, platform);
             connection = connection?.MergeInto(fromInst) ?? fromInst;
         }
 
@@ -916,7 +936,7 @@ public sealed class EdgeDBConnection
             }
             else
             {
-                var fromDSN = FromDSN(dsn);
+                var fromDSN = _FromDSN(dsn, platform);
                 connection = connection?.MergeInto(fromDSN) ?? fromDSN;
             }
         }

--- a/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
+++ b/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
@@ -512,14 +512,14 @@ public sealed class EdgeDBConnection
         if (!platform.FileExists(path))
             throw new FileNotFoundException("Couldn't find the specified project file", path);
 
-        path = Path.GetFullPath(path);
+        path = platform.GetFullPath(path);
 
         // get the folder name
-        var dirName = Directory.GetParent(path)!.FullName;
+        var dirName = platform.DirectoryGetParent(path)!.FullName;
 
         var projectDir = ConfigUtils.GetInstanceProjectDirectory(dirName, platform);
 
-        if (!Directory.Exists(projectDir))
+        if (!platform.DirectoryExists(projectDir))
             throw new DirectoryNotFoundException($"Couldn't find project directory for {path}: {projectDir}");
 
         if (!ConfigUtils.TryResolveInstanceCloudProfile(projectDir, out var profile, out var inst, platform) || inst is null)
@@ -558,7 +558,7 @@ public sealed class EdgeDBConnection
 
         if (Regex.IsMatch(name, @"^\w(-?\w)*$"))
         {
-            var configPath = Path.Combine(ConfigUtils.GetCredentialsDir(platform), $"{name}.json");
+            var configPath = platform.CombinePaths(ConfigUtils.GetCredentialsDir(platform), $"{name}.json");
 
             return !platform.FileExists(configPath)
                 ? throw new FileNotFoundException($"Config file couldn't be found at {configPath}")
@@ -594,10 +594,10 @@ public sealed class EdgeDBConnection
 
         while (true)
         {
-            if (platform.FileExists(Path.Combine(dir!, "edgedb.toml")))
-                return _FromProjectFile(Path.Combine(dir!, "edgedb.toml"), platform);
+            if (platform.FileExists(platform.CombinePaths(dir!, "edgedb.toml")))
+                return _FromProjectFile(platform.CombinePaths(dir!, "edgedb.toml"), platform);
 
-            var parent = Directory.GetParent(dir!);
+            var parent = platform.DirectoryGetParent(dir!);
 
             if (parent is null || !parent.Exists)
                 throw new FileNotFoundException("Couldn't resolve edgedb.toml file");

--- a/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
+++ b/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
@@ -479,7 +479,7 @@ public sealed class EdgeDBConnection
             }
             else if (envMatch.Success)
             {
-                var val = Environment.GetEnvironmentVariable(arg.Value, EnvironmentVariableTarget.Process);
+                var val = platform.GetEnvVariable(arg.Value);
 
                 if (val == null)
                     throw new KeyNotFoundException($"Environment variable \"{arg.Value}\" couldn't be found");
@@ -808,45 +808,34 @@ public sealed class EdgeDBConnection
 
         #region Env
 
-
-        Dictionary<string, string> env = new();
-        foreach (DictionaryEntry oldEnvVar in Environment.GetEnvironmentVariables())
-        {
-            object? value = oldEnvVar.Value;
-            if (value is not null)
-            {
-                env[(string)oldEnvVar.Key] = (string)value;
-            }
-        }
-
         var envName = string.Empty;
         var envVar = string.Empty;
 
-        if (GetEnvVariable(env, CLOUD_PROFILE_ENV_NAME, out envName, out envVar))
+        if (platform.GetGelEnvVariable(CLOUD_PROFILE_ENV_NAME, out envName, out envVar))
         {
             connection ??= new EdgeDBConnection();
             connection.CloudProfile = envVar;
         }
 
-        if (GetEnvVariable(env, SECRET_KEY_ENV_NAME, out envName, out envVar))
+        if (platform.GetGelEnvVariable(SECRET_KEY_ENV_NAME, out envName, out envVar))
         {
             connection ??= new EdgeDBConnection();
             connection.SecretKey = envVar;
         }
 
-        if (GetEnvVariable(env, INSTANCE_ENV_NAME, out envName, out envVar))
+        if (platform.GetGelEnvVariable(INSTANCE_ENV_NAME, out envName, out envVar))
         {
             var fromInst = _FromInstanceName(envVar, null, platform);
             connection = connection?.MergeInto(fromInst) ?? fromInst;
         }
 
-        if (GetEnvVariable(env, DSN_ENV_NAME, out envName, out envVar))
+        if (platform.GetGelEnvVariable(DSN_ENV_NAME, out envName, out envVar))
         {
             var fromDSN = _FromDSN(envVar, platform);
             connection = connection?.MergeInto(fromDSN) ?? fromDSN;
         }
 
-        if (GetEnvVariable(env, HOST_ENV_NAME, out envName, out envVar))
+        if (platform.GetGelEnvVariable(HOST_ENV_NAME, out envName, out envVar))
         {
             connection ??= new EdgeDBConnection();
             try
@@ -866,7 +855,7 @@ public sealed class EdgeDBConnection
             }
         }
 
-        if (GetEnvVariable(env, PORT_ENV_NAME, out envName, out envVar))
+        if (platform.GetGelEnvVariable(PORT_ENV_NAME, out envName, out envVar))
         {
             connection ??= new EdgeDBConnection();
 
@@ -877,7 +866,7 @@ public sealed class EdgeDBConnection
             connection.Port = port;
         }
 
-        if (GetEnvVariable(env, CREDENTIALS_FILE_ENV_NAME, out envName, out envVar))
+        if (platform.GetGelEnvVariable(CREDENTIALS_FILE_ENV_NAME, out envName, out envVar))
         {
             // check if file exists
             var path = envVar;
@@ -889,30 +878,30 @@ public sealed class EdgeDBConnection
             connection = connection?.MergeInto(credentials) ?? credentials;
         }
 
-        if (GetEnvVariable(env, USER_ENV_NAME, out envName, out envVar))
+        if (platform.GetGelEnvVariable(USER_ENV_NAME, out envName, out envVar))
         {
             connection ??= new EdgeDBConnection();
             connection.Username = envVar;
         }
 
-        if (GetEnvVariable(env, PASSWORD_ENV_NAME, out envName, out envVar))
+        if (platform.GetGelEnvVariable(PASSWORD_ENV_NAME, out envName, out envVar))
         {
             connection ??= new EdgeDBConnection();
             connection.Password = envVar;
         }
 
-        if (GetEnvVariable(env, DATABASE_ENV_NAME, out envName, out envVar))
+        if (platform.GetGelEnvVariable(DATABASE_ENV_NAME, out envName, out envVar))
         {
             var altName = string.Empty;
             var altVal = string.Empty;
-            if (GetEnvVariable(env, BRANCH_ENV_NAME, out altName, out altVal))
+            if (platform.GetGelEnvVariable(BRANCH_ENV_NAME, out altName, out altVal))
                 throw new ArgumentException($"{envName} conflicts with {altName}");
 
             connection ??= new EdgeDBConnection();
             connection.Database = envVar;
         }
 
-        if (GetEnvVariable(env, BRANCH_ENV_NAME, out envName, out envVar))
+        if (platform.GetGelEnvVariable(BRANCH_ENV_NAME, out envName, out envVar))
         {
             connection ??= new EdgeDBConnection();
             connection.Branch = envVar;
@@ -955,37 +944,6 @@ public sealed class EdgeDBConnection
         }
 
         return connection ?? new EdgeDBConnection();
-    }
-
-    private static bool GetEnvVariable(IReadOnlyDictionary<string, string> env, string key, out string name, out string value)
-    {
-        string edgedbKey = $"EDGEDB_{key}";
-        string? edgedbVal = env.ContainsKey(edgedbKey) ? env[edgedbKey] : null;
-        string gelKey = $"GEL_{key}";
-        string? gelVal = env.ContainsKey(gelKey) ? env[gelKey] : null;
-        if (edgedbVal is not null && gelVal is not null)
-        {
-            Console.WriteLine($"Both GEL_{key} and EDGEDB_{key} are set; EDGEDB_{key} will be ignored");
-        }
-
-        if (gelVal is not null)
-        {
-            name = gelKey;
-            value = gelVal;
-            return true;
-        }
-        else if (edgedbVal is not null)
-        {
-            name = edgedbKey;
-            value = edgedbVal;
-            return true;
-        }
-        else
-        {
-            name = string.Empty;
-            value = string.Empty;
-            return false;
-        }
     }
 
     #endregion

--- a/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
+++ b/src/EdgeDB.Net.Driver/EdgeDBConnection.cs
@@ -1,3 +1,4 @@
+using EdgeDB.Abstractions;
 using EdgeDB.Utils;
 using Newtonsoft.Json;
 using System.Collections;
@@ -494,6 +495,11 @@ public sealed class EdgeDBConnection
     /// <exception cref="DirectoryNotFoundException">The project directory doesn't exist for the supplied toml file.</exception>
     public static EdgeDBConnection FromProjectFile(string path)
     {
+        return _FromProjectFile(path, null);
+    }
+
+    internal static EdgeDBConnection _FromProjectFile(string path, ISystemProvider? platform)
+    {
         if (!File.Exists(path))
             throw new FileNotFoundException("Couldn't find the specified project file", path);
 
@@ -502,7 +508,7 @@ public sealed class EdgeDBConnection
         // get the folder name
         var dirName = Directory.GetParent(path)!.FullName;
 
-        var projectDir = ConfigUtils.GetInstanceProjectDirectory(dirName);
+        var projectDir = ConfigUtils.GetInstanceProjectDirectory(dirName, platform);
 
         if (!Directory.Exists(projectDir))
             throw new DirectoryNotFoundException($"Couldn't find project directory for {path}: {projectDir}");
@@ -534,9 +540,14 @@ public sealed class EdgeDBConnection
     /// <exception cref="ConfigurationException">The configuration is invalid.</exception>
     public static EdgeDBConnection FromInstanceName(string name, string? cloudProfile = null)
     {
+        return _FromInstanceName(name, cloudProfile, null);
+    }
+
+    internal static EdgeDBConnection _FromInstanceName(string name, string? cloudProfile, ISystemProvider? platform)
+    {
         if (Regex.IsMatch(name, @"^\w(-?\w)*$"))
         {
-            var configPath = Path.Combine(ConfigUtils.GetCredentialsDir(), $"{name}.json");
+            var configPath = Path.Combine(ConfigUtils.GetCredentialsDir(platform), $"{name}.json");
 
             return !File.Exists(configPath)
                 ? throw new FileNotFoundException($"Config file couldn't be found at {configPath}")
@@ -546,7 +557,7 @@ public sealed class EdgeDBConnection
         if (Regex.IsMatch(name, @"^([A-Za-z0-9](-?[A-Za-z0-9])*)\/([A-Za-z0-9](-?[A-Za-z0-9])*)$"))
         {
             var conn = new EdgeDBConnection();
-            conn.ParseCloudInstanceName(name, cloudProfile);
+            conn.ParseCloudInstanceName(name, cloudProfile, platform);
             return conn;
         }
 
@@ -679,7 +690,7 @@ public sealed class EdgeDBConnection
         throw new ConfigurationException($"invalid duration {originalText}");
     }
 
-    private void ParseCloudInstanceName(string name, string? cloudProfile = null)
+    private void ParseCloudInstanceName(string name, string? cloudProfile, ISystemProvider? platform)
     {
         if (name.Length > DOMAIN_NAME_MAX_LEN)
         {
@@ -690,7 +701,7 @@ public sealed class EdgeDBConnection
 
         if (secretKey is null)
         {
-            var profile = ConfigUtils.ReadCloudProfile(cloudProfile ?? CloudProfile);
+            var profile = ConfigUtils.ReadCloudProfile(cloudProfile ?? CloudProfile, platform);
 
             if (profile.SecretKey is null)
             {
@@ -752,6 +763,12 @@ public sealed class EdgeDBConnection
     /// <exception cref="FileNotFoundException">A configuration file could not be found.</exception>
     public static EdgeDBConnection Parse(string? instance = null, string? dsn = null,
         Action<EdgeDBConnection>? configure = null, bool autoResolve = true)
+    {
+        return _Parse(instance, dsn, configure, autoResolve, null);
+    }
+
+    internal static EdgeDBConnection _Parse(string? instance, string? dsn,
+        Action<EdgeDBConnection>? configure, bool autoResolve, ISystemProvider? platform)
     {
         EdgeDBConnection? connection = null;
 
@@ -895,7 +912,7 @@ public sealed class EdgeDBConnection
             {
                 // cloud
                 connection ??= new EdgeDBConnection();
-                connection.ParseCloudInstanceName(dsn);
+                connection.ParseCloudInstanceName(dsn, null, platform);
             }
             else
             {

--- a/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
+++ b/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
@@ -10,6 +10,7 @@ internal interface ISystemProvider
     string CombinePaths(params string[] paths);
     string GetFullPath(string path);
     bool DirectoryExists(string dir);
+    DirectoryInfo? DirectoryGetParent(string dir);
     bool IsRooted(string path);
     string? GetEnvVariable(string name);
     bool FileExists(string path);
@@ -23,6 +24,9 @@ internal sealed class DefaultSystemProvider : ISystemProvider
 
     public bool DirectoryExists(string dir)
         => Directory.Exists(dir);
+
+    public DirectoryInfo? DirectoryGetParent(string dir)
+        => Directory.GetParent(dir);
 
     public string CombinePaths(params string[] paths)
         => Path.Combine(paths);

--- a/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
+++ b/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
@@ -12,6 +12,8 @@ internal interface ISystemProvider
     bool DirectoryExists(string dir);
     bool IsRooted(string path);
     string? GetEnvVariable(string name);
+    bool FileExists(string path);
+    string FileReadAllText(string path);
 }
 
 internal sealed class DefaultSystemProvider : ISystemProvider
@@ -39,4 +41,10 @@ internal sealed class DefaultSystemProvider : ISystemProvider
 
     public string? GetEnvVariable(string name)
         => Environment.GetEnvironmentVariable(name);
+
+    public bool FileExists(string path)
+        => File.Exists(path);
+
+    public string FileReadAllText(string path)
+        => File.ReadAllText(path);
 }

--- a/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
+++ b/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
@@ -17,38 +17,42 @@ internal interface ISystemProvider
     string FileReadAllText(string path);
 }
 
-internal sealed class DefaultSystemProvider : ISystemProvider
+internal class BaseDefaultSystemProvider : ISystemProvider
 {
-    public char DirectorySeparatorChar
+    public virtual char DirectorySeparatorChar
         => Path.DirectorySeparatorChar;
 
-    public bool DirectoryExists(string dir)
+    public virtual bool DirectoryExists(string dir)
         => Directory.Exists(dir);
 
-    public DirectoryInfo? DirectoryGetParent(string dir)
+    public virtual DirectoryInfo? DirectoryGetParent(string dir)
         => Directory.GetParent(dir);
 
-    public string CombinePaths(params string[] paths)
+    public virtual string CombinePaths(params string[] paths)
         => Path.Combine(paths);
 
-    public string GetFullPath(string path)
+    public virtual string GetFullPath(string path)
         => Path.GetFullPath(path);
 
-    public string GetHomeDir()
+    public virtual string GetHomeDir()
         => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
-    public bool IsOSPlatform(OSPlatform platform)
+    public virtual bool IsOSPlatform(OSPlatform platform)
         => RuntimeInformation.IsOSPlatform(platform);
 
-    public bool IsRooted(string path)
+    public virtual bool IsRooted(string path)
         => Path.IsPathRooted(path);
 
-    public string? GetEnvVariable(string name)
+    public virtual string? GetEnvVariable(string name)
         => Environment.GetEnvironmentVariable(name);
 
-    public bool FileExists(string path)
+    public virtual bool FileExists(string path)
         => File.Exists(path);
 
-    public string FileReadAllText(string path)
+    public virtual string FileReadAllText(string path)
         => File.ReadAllText(path);
+}
+
+internal sealed class DefaultSystemProvider : BaseDefaultSystemProvider
+{
 }

--- a/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
+++ b/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
@@ -8,6 +8,7 @@ internal interface ISystemProvider
 {
     char DirectorySeparatorChar { get; }
     string GetHomeDir();
+    string GetCurrentDirectory();
     bool IsOSPlatform(OSPlatform platform);
     string CombinePaths(params string[] paths);
     string GetFullPath(string path);
@@ -69,6 +70,9 @@ internal class BaseDefaultSystemProvider : ISystemProvider
 
     public virtual string GetHomeDir()
         => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+    public virtual string GetCurrentDirectory()
+        => Environment.CurrentDirectory;
 
     public virtual bool IsOSPlatform(OSPlatform platform)
         => RuntimeInformation.IsOSPlatform(platform);

--- a/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
+++ b/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
@@ -18,6 +18,7 @@ internal interface ISystemProvider
     string? GetEnvVariable(string name);
     bool FileExists(string path);
     string FileReadAllText(string path);
+    void WriteWarning(string message);
 
     public virtual bool GetGelEnvVariable(string key, out string name, out string value)
     {
@@ -27,7 +28,7 @@ internal interface ISystemProvider
         string? gelVal = GetEnvVariable(gelKey);
         if (edgedbVal is not null && gelVal is not null)
         {
-            Console.WriteLine($"Both GEL_{key} and EDGEDB_{key} are set; EDGEDB_{key} will be ignored");
+            WriteWarning($"Both GEL_{key} and EDGEDB_{key} are set; EDGEDB_{key} will be ignored");
         }
 
         if (gelVal is not null)
@@ -88,6 +89,9 @@ internal class BaseDefaultSystemProvider : ISystemProvider
 
     public virtual string FileReadAllText(string path)
         => File.ReadAllText(path);
+
+    public virtual void WriteWarning(string message)
+        => Console.WriteLine(message);
 }
 
 internal sealed class DefaultSystemProvider : BaseDefaultSystemProvider

--- a/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
+++ b/src/EdgeDB.Net.Driver/Models/ISystemProvider.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Collections.ObjectModel;
 using System.Runtime.InteropServices;
 
 namespace EdgeDB.Abstractions;
@@ -15,6 +17,37 @@ internal interface ISystemProvider
     string? GetEnvVariable(string name);
     bool FileExists(string path);
     string FileReadAllText(string path);
+
+    public virtual bool GetGelEnvVariable(string key, out string name, out string value)
+    {
+        string edgedbKey = $"EDGEDB_{key}";
+        string? edgedbVal = GetEnvVariable(edgedbKey);
+        string gelKey = $"GEL_{key}";
+        string? gelVal = GetEnvVariable(gelKey);
+        if (edgedbVal is not null && gelVal is not null)
+        {
+            Console.WriteLine($"Both GEL_{key} and EDGEDB_{key} are set; EDGEDB_{key} will be ignored");
+        }
+
+        if (gelVal is not null)
+        {
+            name = gelKey;
+            value = gelVal;
+            return true;
+        }
+        else if (edgedbVal is not null)
+        {
+            name = edgedbKey;
+            value = edgedbVal;
+            return true;
+        }
+        else
+        {
+            name = string.Empty;
+            value = string.Empty;
+            return false;
+        }
+    }
 }
 
 internal class BaseDefaultSystemProvider : ISystemProvider

--- a/src/EdgeDB.Net.Driver/Utils/ConfigUtils.cs
+++ b/src/EdgeDB.Net.Driver/Utils/ConfigUtils.cs
@@ -12,7 +12,7 @@ internal static class ConfigUtils
 {
     private static readonly ISystemProvider _defaultPlatformProvider = new DefaultSystemProvider();
 
-    private static string GetEdgeDBKnownBasePath(ISystemProvider? platform = null)
+    private static string GetEdgeDBKnownBasePath(ISystemProvider? platform)
     {
         platform ??= _defaultPlatformProvider;
 
@@ -28,7 +28,7 @@ internal static class ConfigUtils
         return platform.CombinePaths(xdgConfigDir, "edgedb");
     }
 
-    private static string GetEdgeDBBasePath(ISystemProvider? platform = null)
+    private static string GetEdgeDBBasePath(ISystemProvider? platform)
     {
         platform ??= _defaultPlatformProvider;
 
@@ -38,7 +38,7 @@ internal static class ConfigUtils
             : platform.CombinePaths(platform.GetHomeDir(), ".edgedb");
     }
 
-    public static string GetInstanceProjectDirectory(string projectDir, ISystemProvider? platform = null)
+    public static string GetInstanceProjectDirectory(string projectDir, ISystemProvider? platform)
     {
         platform ??= _defaultPlatformProvider;
 
@@ -55,12 +55,12 @@ internal static class ConfigUtils
         return platform.CombinePaths(GetEdgeDBConfigDir(platform), "projects", $"{baseName}-{hash.ToLower()}");
     }
 
-    public static string GetEdgeDBConfigDir(ISystemProvider? platform = null)
+    public static string GetEdgeDBConfigDir(ISystemProvider? platform)
         => (platform ?? _defaultPlatformProvider).IsOSPlatform(OSPlatform.Windows)
             ? (platform ?? _defaultPlatformProvider).CombinePaths(GetEdgeDBBasePath(platform), "config")
             : GetEdgeDBBasePath(platform);
 
-    public static string GetCredentialsDir(ISystemProvider? platform = null)
+    public static string GetCredentialsDir(ISystemProvider? platform)
         => (platform ?? _defaultPlatformProvider).CombinePaths(GetEdgeDBConfigDir(platform), "credentials");
 
     public static bool TryResolveInstanceTOML([NotNullWhen(true)] out string? tomlPath)
@@ -112,7 +112,7 @@ internal static class ConfigUtils
         return false;
     }
 
-    public static bool TryResolveInstanceCloudProfile(out string? profile, out string? linkedInstanceName)
+    public static bool TryResolveInstanceCloudProfile(out string? profile, out string? linkedInstanceName, ISystemProvider? platform)
     {
         profile = null;
         linkedInstanceName = null;
@@ -120,7 +120,7 @@ internal static class ConfigUtils
         if (!TryResolveInstanceTOML(out var toml))
             return false;
 
-        var stashDir = GetInstanceProjectDirectory(Directory.GetParent(toml)!.FullName!);
+        var stashDir = GetInstanceProjectDirectory(Directory.GetParent(toml)!.FullName!, platform);
 
         return TryResolveInstanceCloudProfile(stashDir, out profile, out linkedInstanceName);
     }
@@ -151,7 +151,7 @@ internal static class ConfigUtils
         return profile is not null || linkedInstanceName is not null;
     }
 
-    public static CloudProfile ReadCloudProfile(string profile, ISystemProvider? platform = null)
+    public static CloudProfile ReadCloudProfile(string profile, ISystemProvider? platform)
     {
         platform ??= _defaultPlatformProvider;
 

--- a/src/EdgeDB.Net.Driver/Utils/ConfigUtils.cs
+++ b/src/EdgeDB.Net.Driver/Utils/ConfigUtils.cs
@@ -74,7 +74,7 @@ internal static class ConfigUtils
 
         while (true)
         {
-            var target = Path.Combine(dir!, "edgedb.toml");
+            var target = platform.CombinePaths(dir!, "edgedb.toml");
 
             if (platform.FileExists(target))
             {
@@ -83,7 +83,7 @@ internal static class ConfigUtils
             }
 
 
-            var parent = Directory.GetParent(dir!);
+            var parent = platform.DirectoryGetParent(dir!);
 
             if (parent is null || !parent.Exists)
                 break;
@@ -102,10 +102,10 @@ internal static class ConfigUtils
 
         database = null;
 
-        if (!Directory.Exists(stashDir))
+        if (!platform.DirectoryExists(stashDir))
             return false;
 
-        var databasePath = Path.Combine(stashDir, "database");
+        var databasePath = platform.CombinePaths(stashDir, "database");
 
         if (platform.FileExists(databasePath))
         {
@@ -118,13 +118,15 @@ internal static class ConfigUtils
 
     public static bool TryResolveInstanceCloudProfile(out string? profile, out string? linkedInstanceName, ISystemProvider? platform)
     {
+        platform ??= DefaultPlatformProvider;
+
         profile = null;
         linkedInstanceName = null;
 
         if (!TryResolveInstanceTOML(out var toml, platform))
             return false;
 
-        var stashDir = GetInstanceProjectDirectory(Directory.GetParent(toml)!.FullName!, platform);
+        var stashDir = GetInstanceProjectDirectory(platform.DirectoryGetParent(toml)!.FullName!, platform);
 
         return TryResolveInstanceCloudProfile(stashDir, out profile, out linkedInstanceName, platform);
     }
@@ -137,17 +139,17 @@ internal static class ConfigUtils
         profile = null;
         linkedInstanceName = null;
 
-        if (!Directory.Exists(stashDir))
+        if (!platform.DirectoryExists(stashDir))
             return false;
 
-        var cloudProfilePath = Path.Combine(stashDir, "cloud-profile");
+        var cloudProfilePath = platform.CombinePaths(stashDir, "cloud-profile");
 
         if (platform.FileExists(cloudProfilePath))
         {
             profile = platform.FileReadAllText(cloudProfilePath);
         }
 
-        var linkedInstancePath = Path.Combine(stashDir, "instance-name");
+        var linkedInstancePath = platform.CombinePaths(stashDir, "instance-name");
 
         if (platform.FileExists(linkedInstancePath))
         {

--- a/src/EdgeDB.Net.Driver/Utils/ConfigUtils.cs
+++ b/src/EdgeDB.Net.Driver/Utils/ConfigUtils.cs
@@ -10,11 +10,11 @@ namespace EdgeDB.Utils;
 
 internal static class ConfigUtils
 {
-    private static readonly ISystemProvider _defaultPlatformProvider = new DefaultSystemProvider();
+    internal static ISystemProvider DefaultPlatformProvider { get; } = new DefaultSystemProvider();
 
     private static string GetEdgeDBKnownBasePath(ISystemProvider? platform)
     {
-        platform ??= _defaultPlatformProvider;
+        platform ??= DefaultPlatformProvider;
 
         if (platform.IsOSPlatform(OSPlatform.Windows))
             return platform.CombinePaths(platform.GetHomeDir(), "AppData", "Local", "EdgeDB");
@@ -30,7 +30,7 @@ internal static class ConfigUtils
 
     private static string GetEdgeDBBasePath(ISystemProvider? platform)
     {
-        platform ??= _defaultPlatformProvider;
+        platform ??= DefaultPlatformProvider;
 
         var basePath = GetEdgeDBKnownBasePath(platform);
         return platform.DirectoryExists(basePath)
@@ -40,7 +40,7 @@ internal static class ConfigUtils
 
     public static string GetInstanceProjectDirectory(string projectDir, ISystemProvider? platform)
     {
-        platform ??= _defaultPlatformProvider;
+        platform ??= DefaultPlatformProvider;
 
         var fullPath = platform.GetFullPath(projectDir);
         var baseName = projectDir.Split(platform.DirectorySeparatorChar).Last();
@@ -56,25 +56,27 @@ internal static class ConfigUtils
     }
 
     public static string GetEdgeDBConfigDir(ISystemProvider? platform)
-        => (platform ?? _defaultPlatformProvider).IsOSPlatform(OSPlatform.Windows)
-            ? (platform ?? _defaultPlatformProvider).CombinePaths(GetEdgeDBBasePath(platform), "config")
+        => (platform ?? DefaultPlatformProvider).IsOSPlatform(OSPlatform.Windows)
+            ? (platform ?? DefaultPlatformProvider).CombinePaths(GetEdgeDBBasePath(platform), "config")
             : GetEdgeDBBasePath(platform);
 
     public static string GetCredentialsDir(ISystemProvider? platform)
-        => (platform ?? _defaultPlatformProvider).CombinePaths(GetEdgeDBConfigDir(platform), "credentials");
+        => (platform ?? DefaultPlatformProvider).CombinePaths(GetEdgeDBConfigDir(platform), "credentials");
 
-    public static bool TryResolveInstanceTOML([NotNullWhen(true)] out string? tomlPath)
-        => TryResolveInstanceTOML(Environment.CurrentDirectory, out tomlPath);
+    public static bool TryResolveInstanceTOML([NotNullWhen(true)] out string? tomlPath, ISystemProvider? platform)
+        => TryResolveInstanceTOML(Environment.CurrentDirectory, out tomlPath, platform);
 
-    public static bool TryResolveInstanceTOML(string cdir, [NotNullWhen(true)] out string? tomlPath)
+    public static bool TryResolveInstanceTOML(string cdir, [NotNullWhen(true)] out string? tomlPath, ISystemProvider? platform)
     {
+        platform ??= DefaultPlatformProvider;
+
         var dir = cdir;
 
         while (true)
         {
             var target = Path.Combine(dir!, "edgedb.toml");
 
-            if (File.Exists(target))
+            if (platform.FileExists(target))
             {
                 tomlPath = target;
                 return true;
@@ -94,8 +96,10 @@ internal static class ConfigUtils
         return false;
     }
 
-    public static bool TryResolveProjectDatabase(string stashDir, [NotNullWhen(true)] out string? database)
+    public static bool TryResolveProjectDatabase(string stashDir, [NotNullWhen(true)] out string? database, ISystemProvider? platform)
     {
+        platform ??= DefaultPlatformProvider;
+
         database = null;
 
         if (!Directory.Exists(stashDir))
@@ -103,9 +107,9 @@ internal static class ConfigUtils
 
         var databasePath = Path.Combine(stashDir, "database");
 
-        if (File.Exists(databasePath))
+        if (platform.FileExists(databasePath))
         {
-            database = File.ReadAllText(databasePath);
+            database = platform.FileReadAllText(databasePath);
             return true;
         }
 
@@ -117,17 +121,19 @@ internal static class ConfigUtils
         profile = null;
         linkedInstanceName = null;
 
-        if (!TryResolveInstanceTOML(out var toml))
+        if (!TryResolveInstanceTOML(out var toml, platform))
             return false;
 
         var stashDir = GetInstanceProjectDirectory(Directory.GetParent(toml)!.FullName!, platform);
 
-        return TryResolveInstanceCloudProfile(stashDir, out profile, out linkedInstanceName);
+        return TryResolveInstanceCloudProfile(stashDir, out profile, out linkedInstanceName, platform);
     }
 
     public static bool TryResolveInstanceCloudProfile(string stashDir, out string? profile,
-        out string? linkedInstanceName)
+        out string? linkedInstanceName, ISystemProvider? platform)
     {
+        platform ??= DefaultPlatformProvider;
+
         profile = null;
         linkedInstanceName = null;
 
@@ -136,16 +142,16 @@ internal static class ConfigUtils
 
         var cloudProfilePath = Path.Combine(stashDir, "cloud-profile");
 
-        if (File.Exists(cloudProfilePath))
+        if (platform.FileExists(cloudProfilePath))
         {
-            profile = File.ReadAllText(cloudProfilePath);
+            profile = platform.FileReadAllText(cloudProfilePath);
         }
 
         var linkedInstancePath = Path.Combine(stashDir, "instance-name");
 
-        if (File.Exists(linkedInstancePath))
+        if (platform.FileExists(linkedInstancePath))
         {
-            linkedInstanceName = File.ReadAllText(linkedInstancePath);
+            linkedInstanceName = platform.FileReadAllText(linkedInstancePath);
         }
 
         return profile is not null || linkedInstanceName is not null;
@@ -153,13 +159,13 @@ internal static class ConfigUtils
 
     public static CloudProfile ReadCloudProfile(string profile, ISystemProvider? platform)
     {
-        platform ??= _defaultPlatformProvider;
+        platform ??= DefaultPlatformProvider;
 
         var profilePath = platform.CombinePaths(GetEdgeDBConfigDir(platform), "cloud-credentials", $"{profile}.json");
 
-        if (!File.Exists(profilePath))
+        if (!platform.FileExists(profilePath))
             throw new ConfigurationException($"Unknown cloud profile '{profile}'");
 
-        return JsonConvert.DeserializeObject<CloudProfile>(File.ReadAllText(profilePath))!;
+        return JsonConvert.DeserializeObject<CloudProfile>(platform.FileReadAllText(profilePath))!;
     }
 }

--- a/src/EdgeDB.Net.Driver/Utils/ConfigUtils.cs
+++ b/src/EdgeDB.Net.Driver/Utils/ConfigUtils.cs
@@ -64,7 +64,11 @@ internal static class ConfigUtils
         => (platform ?? DefaultPlatformProvider).CombinePaths(GetEdgeDBConfigDir(platform), "credentials");
 
     public static bool TryResolveInstanceTOML([NotNullWhen(true)] out string? tomlPath, ISystemProvider? platform)
-        => TryResolveInstanceTOML(Environment.CurrentDirectory, out tomlPath, platform);
+    {
+        platform ??= DefaultPlatformProvider;
+
+        return TryResolveInstanceTOML(platform.GetCurrentDirectory(), out tomlPath, platform);
+    }
 
     public static bool TryResolveInstanceTOML(string cdir, [NotNullWhen(true)] out string? tomlPath, ISystemProvider? platform)
     {

--- a/tests/EdgeDB.Tests.Unit/ConnectionTests.cs
+++ b/tests/EdgeDB.Tests.Unit/ConnectionTests.cs
@@ -1,6 +1,8 @@
+using EdgeDB.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace EdgeDB.Tests.Unit;
 
@@ -188,31 +190,13 @@ public class ConnectionTests
     {
         try
         {
-            // set envs
-            if (envVars is not null)
-            {
-                foreach (var env in envVars)
-                {
-                    Environment.SetEnvironmentVariable(env.Key, env.Value);
-                }
-            }
+            MockSystemProvider mockSystem = new(envVars ?? new());
 
-            return EdgeDBConnection.Parse(dsn: dsn, configure: configure, autoResolve: false);
+            return EdgeDBConnection._Parse(instance: null, dsn: dsn, configure: configure, autoResolve: false, platform: mockSystem);
         }
         catch (Exception x)
         {
             return x;
-        }
-        finally
-        {
-            // clear env variables
-            if (envVars is not null)
-            {
-                foreach (var env in envVars)
-                {
-                    Environment.SetEnvironmentVariable(env.Key, null);
-                }
-            }
         }
     }
 
@@ -223,6 +207,21 @@ public class ConnectionTests
 
         public static implicit operator Result(EdgeDBConnection c) => new() {Connection = c};
         public static implicit operator Result(Exception x) => new() {Exception = x};
+    }
+
+    private class MockSystemProvider : BaseDefaultSystemProvider
+    {
+        private readonly Dictionary<string, string> _envVars;
+
+        public MockSystemProvider(Dictionary<string, string> envVars)
+        {
+            _envVars = envVars;
+        }
+
+        public override string? GetEnvVariable(string name)
+            => _envVars.TryGetValue(name, out var val)
+                ? val
+                : null;
     }
 
     #endregion

--- a/tests/EdgeDB.Tests.Unit/ProjectPathHashingTest.cs
+++ b/tests/EdgeDB.Tests.Unit/ProjectPathHashingTest.cs
@@ -116,5 +116,8 @@ public class ProjectPathHashingTest
 
         public string FileReadAllText(string path)
             => File.ReadAllText(path);
+
+        public virtual void WriteWarning(string message)
+            => Console.WriteLine(message);
     }
 }

--- a/tests/EdgeDB.Tests.Unit/ProjectPathHashingTest.cs
+++ b/tests/EdgeDB.Tests.Unit/ProjectPathHashingTest.cs
@@ -90,6 +90,9 @@ public class ProjectPathHashingTest
         public bool DirectoryExists(string dir)
             => _dirs.Any(x => x == dir || x.StartsWith(dir));
 
+        public DirectoryInfo? DirectoryGetParent(string dir)
+            => Directory.GetParent(dir);
+
         public string GetFullPath(string path)
             => path;
 

--- a/tests/EdgeDB.Tests.Unit/ProjectPathHashingTest.cs
+++ b/tests/EdgeDB.Tests.Unit/ProjectPathHashingTest.cs
@@ -3,6 +3,7 @@ using EdgeDB.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -54,12 +55,7 @@ public class ProjectPathHashingTest
         var mockSystem = new MockSystemProvider(platform, homeDir,
             new Dictionary<string, string> {{"XDG_CONFIG_HOME", xdgconf!}}, projectDir, xdgconf ?? "/", expectedResult);
 
-        if (xdgconf is not null)
-            Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", xdgconf);
-
         var result = ConfigUtils.GetInstanceProjectDirectory(projectDir, mockSystem);
-
-        Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", null);
 
         Assert.AreEqual(expectedResult, result);
     }

--- a/tests/EdgeDB.Tests.Unit/ProjectPathHashingTest.cs
+++ b/tests/EdgeDB.Tests.Unit/ProjectPathHashingTest.cs
@@ -95,6 +95,9 @@ public class ProjectPathHashingTest
         public string GetHomeDir()
             => _home;
 
+        public virtual string GetCurrentDirectory()
+            => Environment.CurrentDirectory;
+
         public bool IsOSPlatform(OSPlatform platform)
             => platform.Equals(_platform);
 

--- a/tests/EdgeDB.Tests.Unit/ProjectPathHashingTest.cs
+++ b/tests/EdgeDB.Tests.Unit/ProjectPathHashingTest.cs
@@ -108,5 +108,11 @@ public class ProjectPathHashingTest
             => _env.TryGetValue(name, out var val)
                 ? val
                 : null;
+
+        public bool FileExists(string path)
+            => File.Exists(path);
+
+        public string FileReadAllText(string path)
+            => File.ReadAllText(path);
     }
 }


### PR DESCRIPTION
The `ISystemProvider` is used when setting up a connection.

This PR expands its functionality so that:
- all access to files, directories, environment variables, operating system, etc. are done via the `ISystemProvider`.
- `EdgeDBConnection` parsing functions have an internal implementation which can take a custom `ISystemProvider`
    - This internal implementation is used by tests.
