### PR TITLE
Update to .Net 8 and fix warnings

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/deploy-prerelease.yml
+++ b/.github/workflows/deploy-prerelease.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
           include-prerelease: true
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
           include-prerelease: true
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
 
     - uses: edgedb/setup-edgedb@v1
       with:

--- a/examples/EdgeDB.Examples.CSharp/EdgeDB.Examples.CSharp.csproj
+++ b/examples/EdgeDB.Examples.CSharp/EdgeDB.Examples.CSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/EdgeDB.Examples.CSharp/Examples/JsonResults.cs
+++ b/examples/EdgeDB.Examples.CSharp/Examples/JsonResults.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using EdgeDB.DataTypes;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace EdgeDB.ExampleApp.Examples;
@@ -11,7 +12,8 @@ internal class JsonResults : IExample
     {
         var result = await client.QueryJsonAsync("select Person {name, email}");
 
-        var people = JsonConvert.DeserializeObject<Person[]>(result)!;
+        var people = JsonConvert.DeserializeObject<Person[]>(result);
+        if (people is null) { return; }
 
         Logger!.LogInformation("People from json: {@People}", people);
     }

--- a/examples/EdgeDB.Examples.ExampleTODOApi/EdgeDB.Examples.ExampleTODOApi.csproj
+++ b/examples/EdgeDB.Examples.ExampleTODOApi/EdgeDB.Examples.ExampleTODOApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/examples/EdgeDB.Examples.FSharp/EdgeDB.Examples.FSharp.fsproj
+++ b/examples/EdgeDB.Examples.FSharp/EdgeDB.Examples.FSharp.fsproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
+++ b/src/EdgeDB.Net.Driver/Clients/EdgeDBBinaryClient.cs
@@ -421,7 +421,14 @@ internal abstract class EdgeDBBinaryClient : BaseEdgeDBClient
             token: token);
 
         return result.ProtocolResult.Data.Any()
-            ? result.ProtocolResult.Data.Select(x => new Json((string?)result.ProtocolResult.OutCodecInfo.Codec.Deserialize(this, in x)))
+            ? result.ProtocolResult.Data
+                .Select(x => 
+                {
+                    object? text = result.ProtocolResult.OutCodecInfo.Codec.Deserialize(this, in x);
+                    return text is string
+                        ? new Json((string)text)
+                        : throw new EdgeDBException("Error parsing JsonElements.");
+                })
                 .ToImmutableArray()
             : ImmutableArray<Json>.Empty;
     }

--- a/src/EdgeDB.Net.Driver/Models/DataTypes/Json.cs
+++ b/src/EdgeDB.Net.Driver/Models/DataTypes/Json.cs
@@ -10,13 +10,13 @@ public readonly struct Json
     /// <summary>
     ///     Gets or sets the raw json value.
     /// </summary>
-    public readonly string? Value;
+    public readonly string Value;
 
     /// <summary>
     ///     Creates a new json type with a provided value.
     /// </summary>
     /// <param name="value">The raw json value of this json object.</param>
-    public Json(string? value)
+    public Json(string value)
     {
         Value = value;
     }
@@ -42,6 +42,6 @@ public readonly struct Json
                 ? serializer.Deserialize<T>(new JsonTextReader(new StringReader(Value)))
                 : EdgeDBConfig.JsonSerializer.DeserializeObject<T>(Value);
 
-    public static implicit operator string?(Json j) => j.Value;
-    public static implicit operator Json(string? value) => new(value);
+    public static implicit operator string(Json j) => j.Value;
+    public static implicit operator Json(string value) => new(value);
 }

--- a/tests/EdgeDB.Tests.Benchmarks/CodecVisitorBenchmarks.cs
+++ b/tests/EdgeDB.Tests.Benchmarks/CodecVisitorBenchmarks.cs
@@ -2,15 +2,4 @@ namespace EdgeDB.Tests.Benchmarks;
 
 public class CodecVisitorBenchmarks
 {
-
-
-    public async Task BenchmarkArgumentVisitor()
-    {
-
-    }
-
-    public async Task BenchmarkResultVisitor()
-    {
-
-    }
 }

--- a/tests/EdgeDB.Tests.Benchmarks/EdgeDB.Tests.Benchmarks.csproj
+++ b/tests/EdgeDB.Tests.Benchmarks/EdgeDB.Tests.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/tests/EdgeDB.Tests.Benchmarks/Utils/MockQueryClient.cs
+++ b/tests/EdgeDB.Tests.Benchmarks/Utils/MockQueryClient.cs
@@ -72,7 +72,6 @@ internal class MockQueryClient : EdgeDBBinaryClient
     {
         private byte[]? _nextBuffer;
         private int _pos;
-        private bool _trigger;
         public override bool CanRead => true;
 
         public override bool CanSeek => true;
@@ -93,7 +92,7 @@ internal class MockQueryClient : EdgeDBBinaryClient
                 _pos += count;
                 return count;
             }
-            catch (Exception x)
+            catch (Exception)
             {
                 return 0;
             }
@@ -108,7 +107,7 @@ internal class MockQueryClient : EdgeDBBinaryClient
                 _pos += buffer.Length;
                 return ValueTask.FromResult(buffer.Length);
             }
-            catch (Exception x)
+            catch (Exception)
             {
                 return ValueTask.FromResult(0);
             }
@@ -142,7 +141,6 @@ internal class MockQueryClient : EdgeDBBinaryClient
                 _ => throw new Exception($"unknown message type {type}")
             };
             _pos = 0;
-            _trigger = true;
         }
     }
 }

--- a/tests/EdgeDB.Tests.Integration/EdgeDB.Tests.Integration.csproj
+++ b/tests/EdgeDB.Tests.Integration/EdgeDB.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/tests/EdgeDB.Tests.Unit/EdgeDB.Tests.Unit.csproj
+++ b/tests/EdgeDB.Tests.Unit/EdgeDB.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/tools/EdgeDB.BinaryDebugger/EdgeDB.BinaryDebugger.csproj
+++ b/tools/EdgeDB.BinaryDebugger/EdgeDB.BinaryDebugger.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tools/EdgeDB.DocGenerator/EdgeDB.DocGenerator.csproj
+++ b/tools/EdgeDB.DocGenerator/EdgeDB.DocGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tools/EdgeDB.DocGenerator/Parser.cs
+++ b/tools/EdgeDB.DocGenerator/Parser.cs
@@ -9,9 +9,9 @@ internal class Parser
 {
     public static DocMember[] Load(string file)
     {
-        var serializer = new XmlSerializer(typeof(doc));
+        var serializer = new XmlSerializer(typeof(Doc));
         using var reader = new StreamReader(file);
-        var t = (doc)serializer.Deserialize(reader)!;
+        var t = (Doc)serializer.Deserialize(reader)!;
 
         var members = t.members!.Select(x => DocMember.FromMember(x)).OrderByDescending(x => x.Type).ToArray();
 
@@ -437,7 +437,7 @@ public enum MemberType
 [DesignerCategory("code")]
 [XmlTypeAttribute(AnonymousType = true)]
 [XmlRootAttribute(Namespace = "", IsNullable = false)]
-public class doc
+public class Doc
 {
     private docAssembly? assemblyField;
 

--- a/tools/EdgeDB.QueryBuilder.OperatorGenerator/EdgeDB.QueryBuilder.OperatorGenerator.csproj
+++ b/tools/EdgeDB.QueryBuilder.OperatorGenerator/EdgeDB.QueryBuilder.OperatorGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tools/EdgeDB.QueryBuilder.OperatorGenerator/Program.cs
+++ b/tools/EdgeDB.QueryBuilder.OperatorGenerator/Program.cs
@@ -186,7 +186,7 @@ void BuildSingleOperator(string section, EdgeQLOperator op)
     writer.AppendLine("using System.Linq.Expressions;");
     writer.AppendLine();
 
-    var cleanedName = Regex.Replace(op.Name, @"(<.*?>)", x => "");
+    var cleanedName = Regex.Replace(op.Name!, @"(<.*?>)", x => "");
 
     using (var _ = writer.BeginScope("namespace EdgeDB.Operators"))
     {


### PR DESCRIPTION
Note: We are currently on a combination of .Net 6 and 7, both of which are no longer supported.